### PR TITLE
Add E2E Encryption Capability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ async function main() {
         const actualService = new ActualService(
             conf.actualServerUrl,
             conf.actualPassword,
+            conf.actualE2eEncryptionPassword,
             conf.actualSyncId,
         );
 

--- a/src/services/actual-service.ts
+++ b/src/services/actual-service.ts
@@ -13,6 +13,7 @@ export class ActualService {
     constructor(
         private readonly serverURL: string,
         private readonly password: string,
+        private readonly e2eEncryptionPassword: string | undefined,
         private readonly syncId: string,
     ) {}
 
@@ -22,7 +23,10 @@ export class ActualService {
             serverURL: this.serverURL,
             password: this.password,
         });
-        await api.downloadBudget(this.syncId);
+        const downloadParams = this.e2eEncryptionPassword
+            ? { password: this.e2eEncryptionPassword }
+            : undefined;
+        await api.downloadBudget(this.syncId, downloadParams);
     }
 
     async importTransactions(

--- a/src/utils/env-validator.ts
+++ b/src/utils/env-validator.ts
@@ -3,6 +3,7 @@ interface EnvConfig {
     AKAHU_USER_TOKEN: string;
     ACTUAL_SERVER_URL: string;
     ACTUAL_PASSWORD: string;
+    ACTUAL_E2E_ENCRYPTION_PASSWORD: string;
     ACTUAL_SYNC_ID: string;
     ACCOUNT_MAPPINGS: string;
     DAYS_TO_FETCH?: string;
@@ -13,6 +14,7 @@ export interface ValidatedConfig {
     akahuUserToken: string;
     actualServerUrl: string;
     actualPassword: string;
+    actualE2eEncryptionPassword: string | undefined;
     actualSyncId: string;
     accountMappings: Record<string, string>;
     daysToFetch: number;
@@ -49,6 +51,7 @@ export function validateEnv(): ValidatedConfig {
         akahuUserToken: process.env.AKAHU_USER_TOKEN!,
         actualServerUrl: process.env.ACTUAL_SERVER_URL!,
         actualPassword: process.env.ACTUAL_PASSWORD!,
+        actualE2eEncryptionPassword: process.env.ACTUAL_E2E_ENCRYPTION_PASSWORD,
         actualSyncId: process.env.ACTUAL_SYNC_ID!,
         accountMappings,
         daysToFetch,


### PR DESCRIPTION
# Overview

This add the ability to use this integration if Actual Budget has end-to-end encryption enabled.

The documentation for how to interface with the Actual "API" with E2E encryption enabled is [here](https://actualbudget.org/docs/api/#connecting-to-a-remote-server).

# Testing

- [x] Test manually with my own instance of Actual Budget with E2E encryption enabled to see if it works

![](https://media0.giphy.com/media/111ebonMs90YLu/200.gif?cid=5a38a5a2q81ystpv7a6frapk5rbt4kz1mzs9a0k08rkcp28n&ep=v1_gifs_search&rid=200.gif&ct=g)